### PR TITLE
Added custom logging to PPO2 and VecMonitor

### DIFF
--- a/roam_rl/baselines/ppo.py
+++ b/roam_rl/baselines/ppo.py
@@ -36,6 +36,9 @@ class PPO:
 
         self.seed = config.getint(section, 'seed')
 
+        info_keywords_str = config.get(section, 'info_keywords', fallback='')
+        self.info_keywords = eval('("'+info_keywords_str+'",)')
+
     def _get_parameter_descr_dict(self):
 
         """
@@ -70,11 +73,11 @@ class PPO:
         logdir = utils.get_log_dir(self.experiment_dir, self.seed)   # setup ppo logging
         logger.configure(dir=logdir, format_strs=['stdout', 'log', 'csv', 'tensorboard'])
         monitor_file_path = os.path.join(logdir, 'monitor.csv')
-        env = self.vec_env_maker(self.env_maker, self.seed, monitor_file=monitor_file_path)
+        env = self.vec_env_maker(self.env_maker, self.seed, monitor_file=monitor_file_path, info_keywords=self.info_keywords)
 
         # Learn
         # pylint: disable=E1125
-        model = self._learn(env=env, **self.params, seed=self.seed, load_path=model_path)   # learn model
+        model = self._learn(env=env, **self.params, seed=self.seed, load_path=model_path, extra_keys=self.info_keywords)   # learn model
 
         # Save
         model.save(utils.get_model_path(self.experiment_dir, self.seed))

--- a/roam_rl/baselines/utils/vec_env_maker.py
+++ b/roam_rl/baselines/utils/vec_env_maker.py
@@ -26,7 +26,7 @@ class VecEnvMaker(object):
         self.normalize_obs = config.getboolean(section, 'normalize_obs', fallback=False)
         self.normalize_ret = config.getboolean(section, 'normalize_ret', fallback=False)
 
-    def __call__(self, env_maker, seed=None, monitor_file=None):
+    def __call__(self, env_maker, seed=None, monitor_file=None, info_keywords=()):
         """
         :param env_maker: instance of roam_learning.robot_env.EnvMaker
         :param seed: int that is used to generate seeds for vectorized envs
@@ -48,7 +48,7 @@ class VecEnvMaker(object):
 
         # Monitor the envs before normalization
         if monitor_file is not None:
-            envs = VecMonitor(envs, filename=monitor_file)
+            envs = VecMonitor(envs, filename=monitor_file, info_keywords=info_keywords)
         if self.normalize_obs or self.normalize_ret:
             envs = VecNormalize(envs, ob=self.normalize_obs, ret=self.normalize_ret, use_tf=True)
         return envs


### PR DESCRIPTION
This lets you specify a tuple of keys to log from the episode info. With the openai/baselines master branch this only works when using a monitored environment. Using [this](https://github.com/openai/baselines/pull/1143) PR, you can also log to all other formats the baselines logger supports.

All changes are backwards compatible, ie. the addition of the `extra_keys` argument to the `self._learn()` call does not break with the master version of openai/baselines 